### PR TITLE
Quote argument-hint so YAML parses it as string

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-crush
 description: Distill a crush into an AI Skill. Import chat history, photos, social media, generate Relationship Memory + Persona, with continuous evolution. | 把暗恋对象蒸馏成 AI Skill，导入聊天记录、照片、朋友圈，生成 Relationship Memory + Persona，支持持续进化。
-argument-hint: [crush-name-or-slug]
+argument-hint: "[crush-name-or-slug]"
 version: 1.0.0
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash


### PR DESCRIPTION
## Summary

The frontmatter in `SKILL.md` currently declares:

```yaml
argument-hint: [crush-name-or-slug]
```

Unquoted square brackets are YAML flow-sequence syntax, so this parses as a **list of one string** (`["crush-name-or-slug"]`) rather than the intended string `"[crush-name-or-slug]"`.

Copilot CLI 1.0.65 tightened its skill/prompt frontmatter schema and now requires `argument-hint` to be a **string**. With the current value, loading this skill fails schema validation. Quoting the value keeps the same rendered hint while satisfying the string requirement:

```yaml
argument-hint: "[crush-name-or-slug]"
```

This also matches the YAML rule cited in the related fixes below:
- `argument-hint: [X]` → `argument-hint: "[X]"`
- `argument-hint: ["X"]` → `argument-hint: "X"`

Claude Code and other consumers accept the quoted form without behavior change, so this is a safe, backward-compatible fix.

## Related

- anthropics/claude-code#22161 — latent version of the same issue on Claude Code

## Test plan

- [x] YAML round-trip: parsing the updated frontmatter with `yaml.safe_load` yields `argument-hint` of type `str` with value `"[crush-name-or-slug]"` (previously a 1-element list).
- [x] Only one file in the repo carried this pattern (`SKILL.md`); a full-tree scan for `argument-hint` returns no other occurrences.
- [x] Load the skill in Copilot CLI 1.0.65 and confirm it no longer fails schema validation.
- [ ] Confirm the hint still renders identically in Claude Code / other consumers.
